### PR TITLE
Déploiements de {{S}} et {{langue}} terminés

### DIFF
--- a/fr.wikt.RemiseEnForme.py
+++ b/fr.wikt.RemiseEnForme.py
@@ -1307,8 +1307,7 @@ def modification(PageHS):
 	regex = ur'{{=([a-z\-]+)=}}'
 	if re.search(regex, PageTemp):
 		PageTemp = re.sub(regex, ur'{{langue|\1}}', PageTemp)
-		if summary.find(u'{{langue}}') == -1: summary = summary + u', déploiement de {{langue}}'
-	
+
 	if page.namespace() == 0 or PageHS.find(u'Utilisateur:JackBot/') != -1:
 		while PageTemp.find(u'{{ ') != -1:
 			PageTemp = PageTemp[0:PageTemp.find(u'{{ ')+2] + PageTemp[PageTemp.find(u'{{ ')+3:len(PageTemp)]
@@ -1339,13 +1338,11 @@ def modification(PageHS):
 			regex = ur'[= ]*{{[\-loc]*(' + Modele[p] + u'|S\|'+ Section[p] + ur')([^}]*)}}[= ]*'
 			if re.search(regex, PageTemp):
 				PageTemp = re.sub(regex, EgalSection + ur' {{S|' + Section[p] + ur'\2}} ' + EgalSection, PageTemp)
-				if summary.find(u'{{S}}') == -1 and re.search('{{-\w', PageBegin): summary = summary + u', [[WT:Prise de décision/Rendre toutes les sections modifiables|déploiement de {{S}}]]'
-			
+
 			regex = ur'[= ]*{{\-flex[\-loc]*(' + Modele[p] + u'|S\|' + Section[p] + ur')\|([^}]*)}}[= ]*'
 			if re.search(regex, PageTemp):
 				PageTemp = re.sub(regex, EgalSection + ur' {{S|' + Section[p] + ur'|\2|flexion}} ' + EgalSection, PageTemp)
-				if summary.find(u'{{S}}') == -1 and re.search('{{-\w', PageBegin): summary = summary + u', [[WT:Prise de décision/Rendre toutes les sections modifiables|déploiement de {{S}}]]'
-		
+
 		if debogageLent: raw_input(PageTemp.encode(config.console_encoding, 'replace'))
 		if PageTemp.find(u'|===') != -1 or PageTemp.find(u'{===') != -1:
 			if debogage: print u' *==='


### PR DESCRIPTION
Il semble plus pertinent de considérer le passage à {{S}} et à {{langue}} comme faisant partie de l'autoformatage dans la mesure où le déploiement à proprement parler de ces deux modèles est terminé
