### PR TITLE
màj contenu par défaut du bac à sable

### DIFF
--- a/clean_sandbox.py
+++ b/clean_sandbox.py
@@ -59,6 +59,7 @@ content = {
     'en': u'{{Sandbox heading}}\n<!-- Hello! Feel free to try your formatting and editing skills below this line. As this page is for editing experiments, this page will automatically be cleaned every 12 hours. -->',
     'fa': u'{{subst:User:Amirobot/sandbox}}',
     'fi': u'{{subst:Hiekka}}',
+    'fr': u'{{Entête bac à sable}}',
     'he': u'{{ארגז חול}}\n<!-- נא לערוך מתחת לשורה זו בלבד, תודה. -->',
     'id': u'{{Bakpasir}}\n<!-- Uji coba dilakukan di baris di bawah ini -->',
     'it': u'{{sandbox}}<!-- Scrivi SOTTO questa riga senza cancellarla. Grazie. -->',


### PR DESCRIPTION
Cf. https://fr.wiktionary.org/w/index.php?title=Wiktionnaire:Bac_%C3%A0_sable&curid=1890174&diff=19911348&oldid=19910540