### PR TITLE
Retrait d'une ligne plus nécessaire et gênante

### DIFF
--- a/clean_sandbox.py
+++ b/clean_sandbox.py
@@ -178,7 +178,6 @@ class SandboxBot:
 					text = sandboxPage.get()
 					translatedContent = pywikibot.translate(self.site, content,fallback=False)
 					translatedMsg = i18n.twtranslate(self.site,'clean_sandbox-cleaned')
-					translatedContent = '{{Sandbox heading}}'
 					subst = 'subst:' in translatedContent
 					pos = text.find(translatedContent.strip())
 					if text.strip() == translatedContent.strip():


### PR DESCRIPTION
Sans doute ajoutée là pour combler l'absence de résumé en français prédéfini, cette ligne empêche le nouveau contenu français d'être pris en compte