### PR TITLE
regex trop gourmand pour le titre de section "dérivés"

### DIFF
--- a/fr.wikt.RemiseEnForme.py
+++ b/fr.wikt.RemiseEnForme.py
@@ -1638,7 +1638,7 @@ def modification(PageC):
 		PageTemp = re.sub(ur'{{S\| ?compos(és)?\|?[a-zé]*}}', u'{{S|composés}}', PageTemp)
 		PageTemp = re.sub(ur'{{S\| ?dial\|?[a-z ]*}}', u'{{S|variantes dialectales}}', PageTemp)
 		PageTemp = re.sub(ur'{{S\| ?dimin(inutifs)?\|?[a-z ]*}}', u'{{S|diminutifs}}', PageTemp)
-		PageTemp = re.sub(ur'{{S\| ?d(é|e)riv(é|e)s?\|?[a-z ]*}}', u'{{S|dérivés}}', PageTemp)
+		PageTemp = re.sub(ur'{{S\| ?d(é|e)riv(é|e)s?(\|[a-z ]*}}|}})', u'{{S|dérivés}}', PageTemp)
 		PageTemp = re.sub(ur'{{S\| ?drv\|?[a-z ]*}}', u'{{S|dérivés}}', PageTemp)
 		PageTemp = re.sub(ur'{{S\| ?dérivés int\|?[a-z ]*}}', u'{{S|dérivés autres langues}}', PageTemp)
 		PageTemp = re.sub(ur'{{S\| ?drv\-int\|?[a-z ]*}}', u'{{S|dérivés autres langues}}', PageTemp)


### PR DESCRIPTION
Le paramètre "dérivés autres langues" de {{S}} est actuellement simplifié en "dérivés" par JackBot ; cf. [cette modif.](https://fr.wiktionary.org/w/index.php?title=coquin&diff=prev&oldid=21884769) ou [celle-ci](https://fr.wiktionary.org/w/index.php?title=%CF%87%CE%AC%CE%BB%CE%B9%CE%BE&diff=prev&oldid=21896104), entre autres