### PR TITLE
Retrait d'une espace superflue

### DIFF
--- a/src/fr.wiktionary.format.py
+++ b/src/fr.wiktionary.format.py
@@ -2590,9 +2590,18 @@ def treatPageByName(pageName):
                 if re.search(regex, pageContent):
                     pageContent = re.sub(regex, ur'\n\4\2}}\1\2\3', pageContent)
 
-                regex = ur'( ===\n)(\'\'\'[^\n]+)({{' + ModeleGent[l][1] + ur'\|[^}]*}})'
+                deplacement_modele_flexion = false
+                # On différencie les cas pas d'espace avant le modèle / espace avant le modèle
+                regex = ur'( ===\n)(\'\'\'[^\n]+[^ ])({{' + ModeleGent[l][1] + ur'\|[^}]*}})'
                 if re.search(regex, pageContent):
                     pageContent = re.sub(regex, ur'\1\3\n\2', pageContent)
+                    deplacement_modele_flexion = true
+                # Espace avant le modèle
+                regex_space = ur'( ===\n)(\'\'\'[^\n]+) ({{' + ModeleGent[l][1] + ur'\|[^}]*}})'
+                if re.search(regex_space, pageContent):
+                    pageContent = re.sub(regex_space, ur'\1\3\n\2', pageContent)
+                    deplacement_modele_flexion = true
+                if deplacement_modele_flexion:
                     summary = summary + u', déplacement des modèles de flexions'
 
 


### PR DESCRIPTION
Espace avant le modèle de flexion à supprimer, afin d'éviter qu'elle reste en fin de ligne ( e.g. https://fr.wiktionary.org/w/index.php?title=Lauragais&diff=prev&oldid=24965502 )
L'autre solution étant de trimer ça à la fin de l'analyse (s'il y a eu d'autres modifications dans la page)