### PR TITLE
Retrait de sgs → bat-smg (traité en interne)

### DIFF
--- a/src/fr.wiktionary.format.py
+++ b/src/fr.wiktionary.format.py
@@ -2219,7 +2219,6 @@ def treatPageByName(pageName):
         pageContent = pageContent.replace(u'- {{source|', u'{{source|')
         pageContent = pageContent.replace(u'#*: {{trad-exe|fr}}', u'')
         pageContent = pageContent.replace(u'\n{{WP', u'\n* {{WP')
-        pageContent = pageContent.replace(u'{{WP|lang=sgs', u'{{WP|lang=bat-smg')
         pageContent = pageContent.replace(u'{{Source-wikt|nan|', u'{{Source-wikt|zh-min-nan|')
 
         # TODO: Factorisation des citations


### PR DESCRIPTION
Suite à https://fr.wiktionary.org/w/index.php?title=Module:langues/data&diff=prev&oldid=25122358 , cette modification de code non-wikimédia de Modèle:WP ne devrait plus être utile.